### PR TITLE
fix case for Sirupsen/logrus

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-Asynchronous and synchronous Stackdriver hooks for logrus (https://github.com/sirupsen/logrus) that internally uses the official Google API (https://godoc.org/cloud.google.com/go/logging).
+Asynchronous and synchronous Stackdriver hooks for logrus (https://github.com/Sirupsen/logrus) that internally uses the official Google API (https://godoc.org/cloud.google.com/go/logging).
 
 See Godoc for examples and API: https://godoc.org/github.com/recursionpharma/stackrus

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ An example:
 	"context"
 
 	"cloud.google.com/go/logging"
-    log "github.com/sirupsen/logrus"
+    log "github.com/Sirupsen/logrus"
 	"github.com/recursionpharma/stackrus"
   )
   func main() {
@@ -33,7 +33,7 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/logging"
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 type Hook struct {


### PR DESCRIPTION
```
$ dep init
[...]
init failed: unable to solve the dependency graph: Solving failure: No versions of github.com/recursionpharma/stackrus met constraints:
        master: Could not introduce github.com/recursionpharma/stackrus@master due to a case-only variation: it depends on "github.com/sirupsen/logrus", but "github.com/Sirupsen/logrus" was already established as the case variant for that project root by depender (root)
```